### PR TITLE
Improved Grass Scheme section

### DIFF
--- a/ACNH/mods/editing_textures.md
+++ b/ACNH/mods/editing_textures.md
@@ -102,5 +102,5 @@ And this shows how the colours in the texture are mapped in game:
 </p>
 
 <p align="center">
-<i>thanks to OpenSauce for this secion</i>
+<i>thanks to OpenSauce for this section</i>
 </p>

--- a/ACNH/mods/editing_textures.md
+++ b/ACNH/mods/editing_textures.md
@@ -86,13 +86,15 @@ Like any other mod, the file must go into the [layeredFs folder](../mods#loading
 
 # Grass Scheme
 
-All of the seasonal grass colors are stored in a texture named `mGrass_Grd`. The vertical axis represents the different seasons, starting from January. Below is the default texture used by the game for grass mapping:
+All of the seasonal grass colors are stored in a texture named `mGrass_Grd`. The vertical axis represents the different seasons, starting from January 1st at the top edge.
+
+Below is the default texture used by the game for grass mapping:
 
 <p align="center">
   <img src="../../assets/images/NH/mods/textures/mGrass_Grd.png" alt="mGrass_Grd"/>
 </p>
 
-And this shows how the colours in the texture are mapped in game:
+And this shows how the colors in the texture are mapped in-game:
 
 <p align="center">
   <img src="../../assets/images/NH/mods/textures/mGrass_Grd_Edit.png" alt="mGrass_Grd Edited to highlight used colours"/>

--- a/ACNH/mods/editing_textures.md
+++ b/ACNH/mods/editing_textures.md
@@ -86,13 +86,13 @@ Like any other mod, the file must go into the [layeredFs folder](../mods#loading
 
 # Grass Scheme
 
-**Grd** (gradient) textures are just that, gradients. All of the seasonal flora colors are stored in a `Grd` texture. The horizontal axis represents a different season. For example, the `mGrass_Grd` for the grass color.
+All of the seasonal grass colors are stored in a texture named `mGrass_Grd`. The vertical axis represents the different seasons, starting from January. Below is the default texture used by the game for grass mapping:
 
 <p align="center">
   <img src="../../assets/images/NH/mods/textures/mGrass_Grd.png" alt="mGrass_Grd"/>
 </p>
 
-The colors mapped in game:
+And this shows how the colours in the texture are mapped in game:
 
 <p align="center">
   <img src="../../assets/images/NH/mods/textures/mGrass_Grd_Edit.png" alt="mGrass_Grd Edited to highlight used colours"/>


### PR DESCRIPTION
This PR edits the Grass Scheme section of the Editing Textures page for correctness and brevity.

It corrects the page incorrectly stating that the horizontal axis is used for mapping seasons, when the vertical axis is in fact used.

Some off-topic details have also been removed, and an additional mention of the texture mapping starting from January has been added.